### PR TITLE
fix :: placeholderTextColor 분리

### DIFF
--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -2,6 +2,7 @@ import { View, TextInput } from "react-native";
 import { InputProps } from "../../types/Input";
 import { styles } from "./styles";
 import { TYPOGRAPHY } from "../../constants/typography";
+import { TEXT_COLORS } from "../../constants/colors";
 
 function Input({placeholder, value, onChangeText} : InputProps){
     return(
@@ -10,7 +11,8 @@ function Input({placeholder, value, onChangeText} : InputProps){
             value = {value}
             onChangeText = {onChangeText}
             style = {[TYPOGRAPHY.INPUT_TEXT, styles.text]}
-            placeholder = {placeholder}/>
+            placeholder = {placeholder}
+            placeholderTextColor={TEXT_COLORS.CAPTION}/>
         </View>
     )
 }

--- a/src/components/input/styles.ts
+++ b/src/components/input/styles.ts
@@ -12,7 +12,7 @@ export const styles = StyleSheet.create({
         backgroundColor : UI_COLORS.BACKGROUND
     },
     text : {
-        color : TEXT_COLORS.CAPTION,
+        color : TEXT_COLORS.DEFAULT,
         textAlign : "left"
     }
 })


### PR DESCRIPTION
## 📝 작업 개요
<!-- 이 PR에서 무엇을 작업했는지 간단히 적어주세요! -->
placeholderTextColor를 따로 지정했습니다

---

## 🔍 작업 상세 내용
<!-- 기능 구현, 수정 사항 등을 구체적으로 적어주세요! -->
- 일반 텍스트 컬러로 변경
- placeholderTextColor를 기존 컬러로 변경

---

## ✅ 체크리스트
- [ ] 관련 이슈와 연결 (`Closes #이슈번호`)
- [x] 기능 구현 또는 수정 완료
- [x] 테스트 완료
- [ ] 코드 리뷰를 위한 설명 작성

---

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 적어주세요! -->
Closes #

---

## 📸 스크린샷 (선택)
<!-- UI 변경이 있을 경우 스크린샷을 첨부해주세요! -->
스크린샷을 올려주세요!

---

## 📎 참고사항 (선택)
<!-- 추가로 공유하고 싶은 참고사항이 있다면 적어주세요! -->
없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 입력 필드의 플레이스홀더 텍스트 색상이 명확하게 지정되었습니다.
  * 입력 텍스트의 색상이 기본 색상으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->