### PR TITLE
fix :: musicNode 클릭시 자세히 보기 페이지로 이동

### DIFF
--- a/src/modules/home/components/MainFunction/MusicNode.tsx
+++ b/src/modules/home/components/MainFunction/MusicNode.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 import { Image, TouchableOpacity, Text } from 'react-native';
 import Animated, { useAnimatedStyle } from 'react-native-reanimated';
 import { styles } from '../../styles/MainFunction/MusicNode';
+import { useNavigation } from '@react-navigation/native';
+import type { NavigationProp } from '@react-navigation/native';
+import type { RootStackParamList } from '../../../../types/navigation';
 import { Dropping } from '../../types/musicList';
 
 interface MusicNodeProps {
@@ -11,6 +14,8 @@ interface MusicNodeProps {
 }
 
 function MusicNode({ data, isMain, index }: MusicNodeProps) {
+    const navigation = useNavigation<NavigationProp<RootStackParamList>>();
+
     // 각 노드의 반지름 설정. 클수록 원의 중심에서 멀어짐.
     const getRadius = () => {
         switch (index) {
@@ -61,9 +66,19 @@ function MusicNode({ data, isMain, index }: MusicNodeProps) {
         };
     });
 
+    const handlePress = () => {
+        navigation.navigate('Music', {
+          droppingId: data.droppingId,
+          title: data.title,
+          artist: data.singer,
+          location: data.address,
+        });
+    };
+
     return (
         <Animated.View style={[styles.nodeContainer, animatedStyle]}>
             <TouchableOpacity
+                onPress={handlePress}
                 style={isMain ? styles.container : styles.subContainer}
             >
                 <Image

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -10,6 +10,7 @@ import DropStack from './DropStack';
 import ProfileStack from './ProfileStack';
 import AuthStack from './AuthStack';
 import HomeScreen from '../modules/home/pages/HomeScreen';
+import MusicScreen from '../modules/music/pages/MusicScreen';
 
 export const navigationRef = createNavigationContainerRef<RootStackParamList>();
 export function navigate<Screen extends keyof RootStackParamList>(
@@ -38,11 +39,12 @@ export default function RootNavigation() {
 
   return (
     <NavigationContainer ref={navigationRef}>
-      <Stack.Navigator initialRouteName={userToken ? 'Home' : 'Auth'}>
+      <Stack.Navigator initialRouteName={'Home'}>
         <Stack.Screen name="Home" component={HomeScreen} options={{ headerShown: false }} />
         <Stack.Screen name="Auth" component={AuthStack} options={{ headerShown: false }} />
         <Stack.Screen name="Profile" component={ProfileStack} options={{ headerShown: false }} />
         <Stack.Screen name="Drop" component={DropStack} options={{ headerShown: false }} />
+        <Stack.Screen name="Music" component={MusicScreen} options={{ headerShown: false }} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -3,6 +3,13 @@ export type RootStackParamList = {
   Auth: undefined;
   Profile: undefined;
   Drop: undefined;
+
+  Music: {
+    droppingId: string;
+    title: string;
+    artist: string;
+    location: string;
+  };
 };
 
 export type ProfileStackParamList = {


### PR DESCRIPTION
## 📝 작업 개요
<!-- 이 PR에서 무엇을 작업했는지 간단히 적어주세요! -->
음악 노드 클릭시 음악 자세히 보기 페이지로 이동하도록 변경했습니다

---

## 🔍 작업 상세 내용
<!-- 기능 구현, 수정 사항 등을 구체적으로 적어주세요! -->
- 음악 노드 클릭시 음악 자세히 보기 페이지로 이동
- stack에 music 추가

---

## ✅ 체크리스트
- [ ] 관련 이슈와 연결 (`Closes #이슈번호`)
- [x] 기능 구현 또는 수정 완료
- [x] 테스트 완료
- [ ] 코드 리뷰를 위한 설명 작성

---

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 적어주세요! -->
Closes #

---

## 📸 스크린샷 (선택)
<!-- UI 변경이 있을 경우 스크린샷을 첨부해주세요! -->
스크린샷을 올려주세요!

---

## 📎 참고사항 (선택)
<!-- 추가로 공유하고 싶은 참고사항이 있다면 적어주세요! -->
cdplayer 이미지, 음악 재생 시간 같은 부분은 음악 util 나온 이후로 다시 수정 필요
