### PR TITLE
fix :: cd 플레이어 url 프롭스 추가

### DIFF
--- a/src/components/cdPlayer/CdPlayer.tsx
+++ b/src/components/cdPlayer/CdPlayer.tsx
@@ -3,7 +3,11 @@ import { useEffect, useRef, useState } from 'react';
 import { styles } from './styles';
 import DiscSvg from './DiscSvg';
 
-function CdPlayer() {
+interface CdPlayerProps {
+    imageUrl: string;
+}
+
+function CdPlayer({ imageUrl }: CdPlayerProps) {
     const [tilt, setTilt] = useState(0);
     const reqRef = useRef<number | null>(null);
 
@@ -20,10 +24,7 @@ function CdPlayer() {
 
     return (
         <View style={styles.container}>
-            <DiscSvg
-                imageUrl="https://entertainimg.kbsmedia.co.kr/cms/uploads/CONTENTS_20230425095757_b457a570577d7444e7cef5c0a6e73bd7.png"
-                tilt={tilt}
-            />
+            <DiscSvg imageUrl={imageUrl} tilt={tilt} />
         </View>
     );
 }


### PR DESCRIPTION
## 📝 작업 개요
<!-- 이 PR에서 무엇을 작업했는지 간단히 적어주세요! -->
cd 플레이어에 url 프롭스를 추가했습니다

---

## 🔍 작업 상세 내용
<!-- 기능 구현, 수정 사항 등을 구체적으로 적어주세요! -->
- url 프롭스 추가

---

## ✅ 체크리스트
- [ ] 관련 이슈와 연결 (`Closes #이슈번호`)
- [x] 기능 구현 또는 수정 완료
- [ ] 테스트 완료
- [ ] 코드 리뷰를 위한 설명 작성

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - CD 플레이어에서 디스크 아트워크를 외부 이미지 URL로 커스터마이즈할 수 있습니다. 고정된 이미지 대신 원하는 앨범 커버를 표시하여 브랜딩·테마에 맞춘 유연한 구성이 가능합니다.
  - 플레이어의 기울기(틸트) 애니메이션 및 기존 상호작용은 유지되어 시각 효과는 동일하게 동작합니다.
  - 페이지나 뷰마다 다른 커버 이미지를 지정해 다양한 콘텐츠를 표현할 수 있으며, UI 전반의 동작에는 영향을 주지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->